### PR TITLE
Switch to using $USER instead of assuming pi

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -50,7 +50,7 @@ while [ $RET -eq 0 ]; do
         sensible-browser "http://inventwithpython.com/pygame"
      else
        if [ "$GAME" != "" ]; then
-          cd /home/pi/python_games
+          cd /home/$USER/python_games
           python $GAME.py
        fi
      fi


### PR DESCRIPTION
Python-games breaks if used on any other user account other than pi. /home/pi shouldn't be assumed.
